### PR TITLE
Fixed the download link by removing trailing /

### DIFF
--- a/thriftDocumentation/source/installation.rst
+++ b/thriftDocumentation/source/installation.rst
@@ -17,7 +17,7 @@ On Ubuntu Linux for example you just need to first install the dependencies and 
 
 	* You can check for specific requirements for each language you wish to use here: http://thrift.apache.org/docs/install/
 
-	#. Download Thrift: http://thrift.apache.org/download/
+	#. Download Thrift: http://thrift.apache.org/download
 
 	#. Copy the downloaded file into the desired directory and untar the file ::
 				


### PR DESCRIPTION
We could also use direct download router http://www.apache.org/dyn/closer.cgi?path=/thrift/0.9.1/thrift-0.9.1.tar.gz instead.
